### PR TITLE
修复crash

### DIFF
--- a/GKNavigationBar.podspec
+++ b/GKNavigationBar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = "GKNavigationBar"
-  s.version                 = "1.0.1"
+  s.version                 = "1.0.2"
   s.summary                 = "自定义导航栏--导航栏联动"
   s.homepage                = "https://github.com/QuintGao/GKNavigationBar"
   s.license                 = "MIT"

--- a/GKNavigationBar.podspec
+++ b/GKNavigationBar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = "GKNavigationBar"
-  s.version                 = "1.0.0"
+  s.version                 = "1.0.1"
   s.summary                 = "自定义导航栏--导航栏联动"
   s.homepage                = "https://github.com/QuintGao/GKNavigationBar"
   s.license                 = "MIT"

--- a/GKNavigationBar/GKCategory/UINavigationItem+GKCategory.m
+++ b/GKNavigationBar/GKCategory/UINavigationItem+GKCategory.m
@@ -26,7 +26,7 @@
                                               @"setRightBarButtonItems:animated:"];
             
             [oriSels enumerateObjectsUsingBlock:^(NSString * _Nonnull oriSel, NSUInteger idx, BOOL * _Nonnull stop) {
-                gk_swizzled_instanceMethod(self, oriSel, self);
+                gk_swizzled_instanceMethod(self, oriSel, [NSObject class]);
             }];
         });
     }


### PR DESCRIPTION
这个bug，我在实际使用中碰到了，一个线上crash。
你看一下这个[注意系统库的坑之load函数调用多次](http://satanwoo.github.io/2017/11/02/load-twice/)
从严谨上来说，既然是明确要替换NSObject分类里的方法，那就直接写`[NSObject class]`，写`self`有风险。