### PR TITLE
[fix]: 开启缩放效果后, 手势异常

### DIFF
--- a/GKNavigationBar/GestureHandle/GKNavigationInteractiveTransition.m
+++ b/GKNavigationBar/GestureHandle/GKNavigationInteractiveTransition.m
@@ -226,7 +226,9 @@
         }
     }else if (transition.x > 0) { // 右滑
         if (!visibleVC.gk_systemGestureHandleDisabled) {
-            [gestureRecognizer addTarget:self.systemTarget action:self.systemAction];
+            if (!self.navigationController.gk_transitionScale) {//没有开启缩放, 添加系统处理
+                [gestureRecognizer addTarget:self.systemTarget action:self.systemAction];
+            }
             BOOL shouldPop = [visibleVC navigationShouldPop];
             if ([visibleVC respondsToSelector:@selector(navigationShouldPopOnGesture)]) {
                 shouldPop = [visibleVC navigationShouldPopOnGesture];


### PR DESCRIPTION
问题现象: 手势往右拖拽一下,手势再往左, 肯定会触发 pop(即使往左恢复到原始位置还是会触发pop 手势)

demo中"今日头条"

我现在定位到的问题是
1.8.7 版本引入的问题
GKNavigationBar/GestureHandle/GKNavigationInteractiveTransition.m中229 行(1.8.7 版本新增的代码)
这里应该判断 是否开启了缩放效果